### PR TITLE
feat: 사이트 설정 및 레이아웃 동적 구성 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "@lucide/astro": "^0.515.0",
     "@tailwindcss/vite": "^4.1.10",
     "astro": "^5.9.3",
+    "js-yaml": "^4.1.0",
     "pagefind": "^1.3.0",
     "sharp": "^0.34.2",
     "tailwindcss": "^4.1.10"
   },
   "devDependencies": {
-    "@tailwindcss/typography": "^0.5.16"
+    "@tailwindcss/typography": "^0.5.16",
+    "@types/js-yaml": "^4.0.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       astro:
         specifier: ^5.9.3
         version: 5.9.3(@types/node@24.0.1)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.43.0)(typescript@5.8.3)
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.1.0
       pagefind:
         specifier: ^1.3.0
         version: 1.3.0
@@ -30,6 +33,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.10)
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
 
 packages:
 
@@ -745,6 +751,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -2413,6 +2422,8 @@ snapshots:
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/mdast@4.0.4':
     dependencies:

--- a/site.yaml
+++ b/site.yaml
@@ -1,0 +1,15 @@
+# Site Configuration
+site:
+  title: "Moseoh"
+  description: "A personal blog theme for Astro."
+
+# Layout Configuration
+layout:
+  # site_width: "1280px" # max-w-7xl
+  # post_width: "768px" # max-w-3xl
+  site_width: "1100px" # max-w-7xl
+  post_width: "860px" # max-w-3xl
+
+# Content Configuration
+content:
+  posts_per_page: 8

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,11 +1,11 @@
 ---
 import { Search } from '@lucide/astro';
-import { SITE } from '../config';
+import { SITE, LAYOUT } from '../config';
 import SearchModal from './SearchModal.astro';
 ---
 
 <header class="border-b border-gray-200">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <div class="mx-auto px-4 sm:px-6 lg:px-8" style={`max-width: ${LAYOUT.siteWidth}`}>
     <div class="flex justify-between items-center h-16">
       <div class="flex-shrink-0">
         <a href="/" class="flex items-center space-x-2">

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,23 @@
+import * as yaml from 'js-yaml';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+// 빌드 시점에 YAML 파일 읽기 (번들링됨)
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const configPath = join(__dirname, '..', '..', 'site.yaml');
+const configFile = readFileSync(configPath, 'utf8');
+const config = yaml.load(configFile) as any;
+
 export const SITE = {
-  title: "Moseoh",
-  description: "A personal blog theme for Astro.",
+  title: config.site.title,
+  description: config.site.description,
 };
 
-export const POSTS_PER_PAGE = 3;
+export const LAYOUT = {
+  siteWidth: config.layout.site_width,
+  postWidth: config.layout.post_width,
+};
+
+export const POSTS_PER_PAGE = config.content.posts_per_page;

--- a/src/pages/[category]/[tag]/[page].astro
+++ b/src/pages/[category]/[tag]/[page].astro
@@ -7,7 +7,7 @@ import PostList from '../../../components/PostList.astro';
 import Sidebar from '../../../components/Sidebar.astro';
 import Pagination from '../../../components/Pagination.astro';
 import type { CollectionEntry } from 'astro:content';
-import { POSTS_PER_PAGE, SITE } from '../../../config';
+import { POSTS_PER_PAGE, SITE, LAYOUT } from '../../../config';
 
 // 1. 빌드 시 가능한 모든 URL 경로 생성
 export async function getStaticPaths() {
@@ -117,7 +117,7 @@ const displayCategory = category === 'all' ? '전체' : (categoryMap.get(categor
 
 <MainLayout title={SITE.title}>
   <Header />
-  <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+  <main class="mx-auto px-4 sm:px-6 lg:px-8" style={`max-width: ${LAYOUT.siteWidth}`}>
     <Banner />
     <div
       class="grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-12 items-start"

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -3,6 +3,7 @@ import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
 import MainLayout from '../../layouts/MainLayout.astro';
 import Header from '../../components/Header.astro';
+import { LAYOUT } from '../../config';
 
 export async function getStaticPaths() {
   const posts = await getCollection('posts', ({ data }) => {
@@ -27,10 +28,7 @@ function formatDate(date: Date) {
 ---
 <MainLayout title={post.data.title}>
   <Header />
-  <article
-    class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12 prose lg:prose-xl"
-    data-pagefind-body
-  >
+  <article class="mx-auto px-4 sm:px-6 lg:px-8 py-12 prose lg:prose-xl" style={`max-width: ${LAYOUT.postWidth}`}>
     <div class="mb-8 text-center">
       <h1 class="text-4xl font-extrabold tracking-tight" data-pagefind-meta="title">
         {post.data.title}


### PR DESCRIPTION
사이트 설정 및 레이아웃을 동적으로 구성할 수 있도록 변경합니다.

- `site.yaml` 파일을 사용하여 사이트 제목, 설명, 레이아웃 너비 등의 설정을 관리합니다.
- `js-yaml` 라이브러리를 사용하여 YAML 파일을 읽고 설정을 적용합니다.
- 컴포넌트에서 하드코딩된 값을 설정 파일에서 읽어오도록 수정하여, 유지보수 및 확장의 용이성을 높입니다.
- 레이아웃 관련 설정 (`site_width`, `post_width`, `posts_per_page`)을 `site.yaml`에서 관리합니다.