### PR TITLE
feat: publishedAt 기반 날짜 시스템 구현

### DIFF
--- a/src/components/Post.astro
+++ b/src/components/Post.astro
@@ -49,7 +49,7 @@ function formatDate(date: Date) {
     <p class="text-base text-gray-500 mb-3">
       <span>{post.data.author.join(', ')}</span>
       <span class="mx-2">·</span>
-      <span>{formatDate(post.data.createdAt)}</span>
+      <span>{formatDate(post.data.publishedAt)}</span>
     </p>
     <!-- 태그들 (Sidebar 스타일과 동일) -->
     <div class="flex flex-wrap gap-2">

--- a/src/components/PostListItem.astro
+++ b/src/components/PostListItem.astro
@@ -43,7 +43,7 @@ function formatDate(date: Date) {
       {post.data.tags.map((tag) => <span class="text-accent-primary">#{tag} </span>)}
     </div>
     <div class="text-sm text-foreground-tertiary mt-1">
-      <span>{formatDate(post.data.createdAt)}</span>
+      <span>{formatDate(post.data.publishedAt)}</span>
       <span class="mx-1">·</span>
       <span>{post.data.author.join(', ')}</span>
     </div>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -16,10 +16,14 @@ const postsCollection = defineCollection({
       summary: z.string(),
       author: z.array(z.string()),
       heroImage: image().nullable(),
-      publishedAt: z.string().nullable(),
+      publishedAt: z.coerce.date().nullable(),
       createdAt: z.coerce.date(),
       updatedAt: z.coerce.date().nullable(),
-    }),
+    }).transform((data) => ({
+      ...data,
+      // publishedAt이 null이면 createdAt을 사용
+      publishedAt: data.publishedAt || data.createdAt,
+    })),
 });
 
 export const collections = {

--- a/src/pages/[category]/[tag]/[page].astro
+++ b/src/pages/[category]/[tag]/[page].astro
@@ -74,7 +74,7 @@ const postsUnfiltered = await getCollection('posts', ({ data }) => {
 });
 
 const sortedPosts = postsUnfiltered.sort(
-  (a, b) => b.data.createdAt.valueOf() - a.data.createdAt.valueOf()
+  (a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf()
 );
 
 const postsForCategory =


### PR DESCRIPTION
## Summary

* 포스트 날짜 시스템을 createdAt에서 publishedAt 기반으로 전환
* publishedAt이 없는 기존 포스트는 createdAt을 자동으로 사용
* 모든 날짜 표시 및 정렬을 publishedAt 기준으로 통일

## Changes

* content/config.ts
  - publishedAt 필드를 Date 타입으로 변경
  - transform 로직으로 publishedAt이 null이면 createdAt을 fallback으로 사용
* PostListItem.astro 및 Post.astro
  - 날짜 표시를 createdAt에서 publishedAt으로 변경
* [category]/[tag]/[page].astro
  - 포스트 정렬 기준을 publishedAt으로 변경
  - 발행 날짜 기준 최신순 정렬 구현

## Benefits

* 포스트 발행 날짜와 실제 작성 날짜를 분리하여 관리 가능
* 기존 포스트 호환성 유지 (자동 fallback)
* 일관된 날짜 기준으로 정렬 및 표시

## Test Plan

* publishedAt이 설정된 포스트의 정렬 및 표시 확인
* publishedAt이 없는 기존 포스트의 fallback 동작 확인
* 포스트 목록과 개별 포스트 페이지의 날짜 일관성 확인